### PR TITLE
real stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "inherits": "~2.0.1",
     "lie": "^2.6.0",
     "pouchdb-extend": "^0.1.2",
-    "split": "^0.3.0"
+    "split": "^0.3.0",
+    "through2": "^0.6.1",
+    "pouch-stream": "^0.4.0"
   },
   "devDependencies": {
     "bluebird": "^1.0.7",


### PR DESCRIPTION
couple updates, writeable-stream is now a transform stream that writes to itself and pipes to the write stream, it also uses prototypes and other big boy javascript features

index.js was updated specifically the load function to be 100% streamy as it's now a pipe that
1. spits the line deliniated json file
2. filters out the black lines and empty doc objects and then emits each doc
3. batches the docs into groups of 50 (this might not be neccisary) 
4. pushes them into the database via my pouch-stream plugin
