### PR TITLE
(#8) - disable browser tests for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,12 @@ env:
   - CLIENT=selenium:phantomjs COMMAND=test
   - COMMAND=coverage
 
+matrix:
+  allow_failures:
+  - env: CLIENT=selenium:firefox COMMAND=test
+  - env: CLIENT=selenium:phantomjs COMMAND=test
+  fast_finish: true
+
 branches:
   only:
   - master


### PR DESCRIPTION
This module might only be used in Node anyway, so browser tests are not totally necessary.
