### PR TITLE
(#10) - add seq checkpoints

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -32,7 +32,6 @@ if (process.browser) {
 } else {
   dbs = process.env.TEST_DB;
 }
-var origN = 180;
 dbs.split(',').forEach(function (db) {
   var dbType = /^http/.test(db) ? 'http' : 'local';
   tests(db, dbType);
@@ -42,8 +41,23 @@ function tests(dbName, dbType) {
 
   var db;
   var remote;
+  var out;
+  var stream;
+  var outStream;
 
   beforeEach(function () {
+    this.timeout(30000);
+    out = [];
+    stream = through(function (chunk, _, next) {
+      out.push(chunk);
+      next();
+    });
+    outStream = noms(function (next) {
+      out.forEach(function (item) {
+        this.push(item);
+      }, this);
+      next(null, null);
+    });
     db = new Pouch(dbName);
     return db.then(function () {
       remote = new Pouch(dbName + '_remote');
@@ -52,26 +66,17 @@ function tests(dbName, dbType) {
   });
 
   afterEach(function () {
+    this.timeout(30000);
     return db.destroy().then(function () {
       return remote.destroy();
     });
   });
+
   describe(dbType + ': hello test suite', function () {
-    origN += 20;
-    var n = origN;
-    var out = [];
-   
-    var stream = through(function (chunk, _, next) {
-      out.push(chunk);
-      next();
-    });
-    var outStream = noms(function (next) {
-      out.forEach(function (item) {
-        this.push(item);
-      }, this);
-      next(null, null);
-    });
-    it('should dump a basic db', function (done) {
+    this.timeout(30000);
+
+    it('should dump and load a basic db', function (done) {
+      var n = 180;
       random(n).pipe(db.createWriteStream()).on('finish', function () {
         db.dump(stream).then(function () {
           out.map(function (item, i) {
@@ -79,21 +84,59 @@ function tests(dbName, dbType) {
               return 1;
             }
             var out = JSON.parse(item);
-            return out.docs.length;
+            return out.docs ? out.docs.length : 0;
           }).reduce(function (a, b) {
             return a + b;
           }).should.equal(n + 1, n + ' docs dumped plus meta data');
+        }).then(function () {
+          return remote.load(outStream);
+        }).then(function () {
+          return remote.allDocs();
+        }).then(function (res) {
+          res.rows.should.have.length(n, n + ' docs replicated');
           done();
         }).catch(done);
       });
     });
-    it('should load a basic db', function (done) {
-      return remote.load(outStream).then(function () {
-        return remote.allDocs();
-      }).then(function (res) {
-        res.rows.should.have.length(n, n + ' docs replicated');
-        done();
-      }).catch(done);
+
+    it('should dump and load an empty db', function (done) {
+      var n = 0;
+      random(n).pipe(db.createWriteStream()).on('finish', function () {
+        db.dump(stream).then(function () {
+          out.map(function (item, i) {
+            if (!i) {
+              return 1;
+            }
+            var out = JSON.parse(item);
+            return out.docs ? out.docs.length : 0;
+          }).reduce(function (a, b) {
+            return a + b;
+          }).should.equal(n + 1, n + ' docs dumped plus meta data');
+        }).then(function () {
+          return remote.load(outStream);
+        }).then(function () {
+          return remote.allDocs();
+        }).then(function (res) {
+          res.rows.should.have.length(n, n + ' docs replicated');
+          done();
+        }).catch(done);
+      });
+    });
+
+    it('should dump with seqs', function (done) {
+      var lastSeq;
+      random(180).pipe(db.createWriteStream()).on('finish', function () {
+        db.dump(stream).then(function () {
+          out.forEach(function (item) {
+            item = JSON.parse(item);
+            if (item.seq) {
+              lastSeq = item.seq;
+            }
+          });
+          lastSeq.should.equal(180);
+          done();
+        }).catch(done);
+      });
     });
   });
 

--- a/writable-stream.js
+++ b/writable-stream.js
@@ -106,7 +106,15 @@ function WritableStreamPouch(opts, callback) {
         callback(ERROR_REV_CONFLICT);
       } else {
         self.localStore[id] = doc;
-        callback(null, {ok: true, id: id, rev: newRev});
+        var done = function () {
+          callback(null, {ok: true, id: id, rev: newRev});
+        };
+        /* istanbul ignore else */
+        if ('last_seq' in doc) {
+          self.ldj.write({seq: doc.last_seq}, done);
+        } else {
+          done();
+        }
       }
     });
   };


### PR DESCRIPTION
I remember now why I suggested including the `seq` in a separate line - it's just easier given the way replication works, since the checkpoints are written as a `_local` doc after the documents themselves are written.

Two more benefits: 1) potentially we could batch the stream, so that the checkpoints come e.g. every 50 docs. 2) it's clearer whether the seq applies before vs. after the written documents.

So I'm happy with this PR.
