### PR TITLE
Enable passing of replication options

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ exports.plugin.dump = utils.toPromise(function (writableStream, opts, callback) 
       db_info: info
     };
     writableStream.write(JSON.stringify(header) + '\n');
-    if(!opts.batch_size){
+    if(!!!opts.batch_size){
       opts.batch_size = DEFAULT_BATCH_SIZE;
     }
     return self.replicate.to(output, opts);

--- a/index.js
+++ b/index.js
@@ -35,10 +35,10 @@ exports.plugin.dump = utils.toPromise(function (writableStream, opts, callback) 
       db_info: info
     };
     writableStream.write(JSON.stringify(header) + '\n');
-    var replicationOpts = {
-      batch_size: opts.batch_size || DEFAULT_BATCH_SIZE 
-    };
-    return self.replicate.to(output, replicationOpts);
+    if(!opts.batch_size){
+      opts.batch_size = DEFAULT_BATCH_SIZE;
+    }
+    return self.replicate.to(output, opts);
   }).then(function () {
     return output.close();
   }).then(function () {


### PR DESCRIPTION
This patch enables the user to pass custom replication options. This is useful for things like filtered replication.