### PR TITLE
Move lodash to dependencies 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage
 test/test-bundle.js
 npm-debug.log
 dist
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ node_modules
 coverage
 npm-debug.log
 vendor/
+.idea

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "inherits": "~2.0.1",
     "ldjson-stream": "^1.2.1",
     "lie": "^2.6.0",
+    "lodash": "^3.3.0",
     "pouch-stream": "^0.4.0",
     "pouchdb-extend": "^0.1.2",
     "through2": "^0.6.1"
@@ -49,7 +50,6 @@
     "http-server": "~0.5.5",
     "istanbul": "^0.2.7",
     "jshint": "~2.3.0",
-    "lodash": "^3.3.0",
     "memorystream": "^0.2.0",
     "mocha": "~1.18",
     "noms": "0.0.0",


### PR DESCRIPTION
Currently the module fails with

```
module.js:324
    throw err;
    ^
Error: Cannot find module 'lodash/object/pick'
    at Function.Module._resolveFilename (module.js:322:15)
    at Function.Module._load (module.js:264:25)
    at Module.require (module.js:351:17)
    at require (module.js:370:17)
    at Object.<anonymous> (/Users/boennemann/Projects/excellenteasy/social-dump/node_modules/pouchdb-replication-stream/index.js:7:12)
    at Module._compile (module.js:446:26)
    at Object.Module._extensions..js (module.js:464:10)
    at Module.load (module.js:341:32)
    at Function.Module._load (module.js:296:12)
    at Module.require (module.js:351:17)
```

This is caused by lodash not being in the dependencies, but only in devDependencies even though it's required in index.js.

Also I noticed that the package on npm contains an .idea folder which should be ignored. I'm sending this along, but can open a different PR if you want me to.
