### PR TITLE
should work with buffers from different browserify bundles

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var version = require('./version');
 var ldj = require('ldjson-stream');
 var through = require('through2').obj;
 var pick = require('lodash/object/pick');
-
+var toBufferStream = require('./to-buffer-stream');
 var DEFAULT_BATCH_SIZE = 50;
 
 // params to the replicate() API that the user is allowed to specify
@@ -80,7 +80,7 @@ exports.plugin.load = utils.toPromise(function (readableStream, opts, callback) 
   }
 
   var queue = [];
-  readableStream.pipe(ldj.parse()).pipe(through(function (data, _, next) {
+  readableStream.pipe(toBufferStream()).pipe(ldj.parse()).pipe(through(function (data, _, next) {
     if (!data.docs) {
       return next();
     }

--- a/to-buffer-stream.js
+++ b/to-buffer-stream.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var through = require('through2').obj;
+
+module.exports = function () {
+  return through(function (chunk, _, next) {
+    if (!(chunk instanceof Buffer) && Buffer.isBuffer(chunk)) {
+      chunk = new Buffer(chunk);
+    }
+    this.push(chunk);
+    next();
+  });
+};


### PR DESCRIPTION
a fix for #29 basically the current version of streams uses this instanceof Buffer to check if something is a buffer but when you combine different browserify bundles (like when using this and simple-peer both as premade bundles) they have different buffer instances.