### PR TITLE
Add known pitfalls to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,19 @@ db.dump(stream).then(function () {
 });
 ```
 
+Known pitfalls
+---
+
+### Read error 400 ECONNRESET
+
+Basically this means your CouchDB cannot handle all concurrent requests happening. Most probable cause is you have 200+ attachments on one of your documents.
+
+One simple way to get around this error is to limit the globalAgent maxSockets, which manages the maximum number of concurret http requests.
+
+```js
+require('http').globalAgent.maxSockets = 25;
+```
+
 Building
 ----
     npm install


### PR DESCRIPTION
Today I hit the described error. The replication protocol will try to fetch all attachments at once. As the global maxSockets setting is Infinity, CouchDB will be hit by an explosion of requests. My setup allowed for 200 attachments to be read at once. If the doc had more attachments then 400 errors started appearing (which is a bug in CouchDB) which would stop the stream. Limiting the global config solved my issue.