### PR TITLE
fix issue with v6.0.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ exports.plugin.dump = utils.toPromise(function (writableStream, opts, callback) 
 
   var PouchDB = self.constructor;
 
-  var output = new PouchDB(self._db_name, {
+  var output = new PouchDB(self.name, {
     adapter: 'writableStream'
   });
   output.setupStream(writableStream);

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   },
   "dependencies": {
     "argsarray": "0.0.1",
-    "inherits": "~2.0.1",
-    "ndjson": "^1.4.3",
+    "inherits": "^2.0.3",
     "lodash.pick": "^4.0.0",
-    "pouchdb-promise": "^5.4.4",
+    "ndjson": "^1.4.3",
     "pouch-stream": "^0.4.0",
+    "pouchdb-promise": "^6.0.4",
     "through2": "^2.0.0"
   },
   "devDependencies": {
@@ -59,7 +59,7 @@
     "mocha": "~1.18",
     "noms": "0.0.0",
     "phantomjs": "^1.9.7-5",
-    "pouchdb-memory": "^1.0.0",
+    "pouchdb-memory": "^6.0.0",
     "random-document-stream": "0.0.0",
     "request": "^2.36.0",
     "sauce-connect-launcher": "^0.4.2",

--- a/test/test.js
+++ b/test/test.js
@@ -56,9 +56,9 @@ function tests(dbName, dbType) {
       next(null, null);
     });
     db = new Pouch(dbName);
-    return db.then(function () {
+    return db.info().then(function () {
       remote = new Pouch(dbName + '_remote');
-      return remote.then(function () {});
+      return remote.info().then(function () {});
     });
   });
 


### PR DESCRIPTION
I have some `Error: Missing/invalid DB name` error thrown when using the latest release of pouchdb.
This PR should fix this issue.

For reference: https://github.com/pouchdb/pouchdb/pull/5435.